### PR TITLE
add openapi generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,18 @@ name = "fastnear-api-server-rs"
 version = "0.10.1"
 edition = "2021"
 
+[features]
+default = []
+openapi = ["dep:fastnear-openapi-generator", "dep:schemars"]
+
 [[bin]]
 path = "src/main.rs"
 name = "server"
+
+[[bin]]
+name = "generate-openapi"
+path = "src/bin/generate-openapi.rs"
+required-features = ["openapi"]
 
 [dependencies]
 actix-web = "4.5.1"
@@ -19,6 +28,7 @@ redis = { version = "0.25.2", features = ["tokio-comp", "tokio-native-tls-comp",
 itertools = "0.12.0"
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tracing-actix-web = "0.7.9"
+anyhow = "1"
 
 near-account-id = "0.1.0"
 near-crypto = "0.20.0"
@@ -27,3 +37,5 @@ reqwest = { version = "0.11.24", features = ["json"] }
 base64 = "0.21.7"
 hex = "0.4.3"
 openssl-probe = "0.1.5"
+fastnear-openapi-generator = { version = "0.2.0", optional = true }
+schemars = { version = "1.2.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -464,10 +464,10 @@ Returns the list of account IDs that are associated with the full-access public 
 GET /v0/public_key/{public_key}
 ```
 
-Example: https://api.fastnear.com/v0/public_key/ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+Example: https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
 
 ```bash
-curl https://api.fastnear.com/v0/public_key/ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+curl https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
 ```
 
 Result:
@@ -475,10 +475,9 @@ Result:
 ```json
 {
   "account_ids": [
-    "root.near",
-    "d9af67ff794a93e05bdba5c25ad7af027d72b3b76823051c0fb4b6e3e79ac51e"
+    "root.near"
   ],
-  "public_key": "ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3"
+  "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"
 }
 ```
 
@@ -490,10 +489,10 @@ Returns the list of account IDs that are associated with this public key, includ
 GET /v0/public_key/{public_key}/all
 ```
 
-Example: https://api.fastnear.com/v0/public_key/ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd/all
+Example: https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT/all
 
 ```bash
-curl https://api.fastnear.com/v0/public_key/ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd/all
+curl https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT/all
 ```
 
 Result:
@@ -501,10 +500,9 @@ Result:
 ```json
 {
   "account_ids": [
-    "root.near",
-    "f2c160840040d637041a5dc63eeb23b8aae41a79fc9b0f2d8df07adb613d1d82"
+    "root.near"
   ],
-  "public_key": "ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd"
+  "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Endpoints:
 - Mainnet: https://api.fastnear.com
 - Testnet: https://test.api.fastnear.com
 
+## OpenAPI Generation
+
+The checked-in `openapi/openapi.yaml` file is generated from typed Rust DTOs and a Rust operation registry.
+
+```bash
+cargo run --features openapi --bin generate-openapi
+cargo run --features openapi --bin generate-openapi -- --check
+```
+
+The docs pipeline is:
+
+`fastnear-api-server-rs` generator -> checked-in `openapi/openapi.yaml` -> `mike-docs` split + sync -> `builder-docs` direct docs runtime
+
 ## Status
 
 You can check status of the API server.
@@ -447,8 +460,6 @@ Result:
 
 Returns the list of account IDs that are associated with the full-access public key.
 
-Note, the API will also return an implicit account ID for the public key, even if the implicit account might not exist.
-
 ```
 GET /v0/public_key/{public_key}
 ```
@@ -474,8 +485,6 @@ Result:
 #### Any Public Key to Account ID mapping.
 
 Returns the list of account IDs that are associated with this public key, including limited access keys.
-
-Note, the API will also return an implicit account ID for the public key, even if the implicit account might not exist.
 
 ```
 GET /v0/public_key/{public_key}/all

--- a/index.html
+++ b/index.html
@@ -515,18 +515,17 @@
 
     <pre><code>GET /v0/public_key/{public_key}</code></pre>
 
-    <p>Example: <a href="https://api.fastnear.com/v0/public_key/ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3">https://api.fastnear.com/v0/public_key/ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3</a></p>
+    <p>Example: <a href="https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT">https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT</a></p>
 
-    <pre><code class="language-bash">curl https://api.fastnear.com/v0/public_key/ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3</code></pre>
+    <pre><code class="language-bash">curl https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT</code></pre>
 
     <p>Result:</p>
 
     <pre><code class="language-json">{
   "account_ids": [
-    "root.near",
-    "d9af67ff794a93e05bdba5c25ad7af027d72b3b76823051c0fb4b6e3e79ac51e"
+    "root.near"
   ],
-  "public_key": "ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3"
+  "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"
 }</code></pre>
 
     <h4>Any Public Key to Account ID mapping.</h4>
@@ -535,18 +534,17 @@
 
     <pre><code>GET /v0/public_key/{public_key}/all</code></pre>
 
-    <p>Example: <a href="https://api.fastnear.com/v0/public_key/ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd/all">https://api.fastnear.com/v0/public_key/ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd/all</a></p>
+    <p>Example: <a href="https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT/all">https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT/all</a></p>
 
-    <pre><code class="language-bash">curl https://api.fastnear.com/v0/public_key/ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd/all</code></pre>
+    <pre><code class="language-bash">curl https://api.fastnear.com/v0/public_key/ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT/all</code></pre>
 
     <p>Result:</p>
 
     <pre><code class="language-json">{
   "account_ids": [
-    "root.near",
-    "f2c160840040d637041a5dc63eeb23b8aae41a79fc9b0f2d8df07adb613d1d82"
+    "root.near"
   ],
-  "public_key": "ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd"
+  "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"
 }</code></pre>
 
     <h4>Account ID to delegated staking pools (validators).</h4>

--- a/index.html
+++ b/index.html
@@ -513,8 +513,6 @@
 
     <p>Returns the list of account IDs that are associated with the full-access public key.</p>
 
-    <p>Note, the API will also return an implicit account ID for the public key, even if the implicit account might not exist.</p>
-
     <pre><code>GET /v0/public_key/{public_key}</code></pre>
 
     <p>Example: <a href="https://api.fastnear.com/v0/public_key/ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3">https://api.fastnear.com/v0/public_key/ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3</a></p>
@@ -534,8 +532,6 @@
     <h4>Any Public Key to Account ID mapping.</h4>
 
     <p>Returns the list of account IDs that are associated with this public key, including limited access keys.</p>
-
-    <p>Note, the API will also return an implicit account ID for the public key, even if the implicit account might not exist.</p>
 
     <pre><code>GET /v0/public_key/{public_key}/all</code></pre>
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -242,7 +242,7 @@ openapi: 3.0.3
 paths:
   /health:
     get:
-      description: Use this lightweight probe to confirm the FastNear API is healthy.
+      description: 'Ping the FastNEAR API for liveness — returns `{status: ok}` when healthy.'
       operationId: get_health
       parameters:
       - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
@@ -308,7 +308,7 @@ paths:
       x-fastnear-title: FastNEAR API - Status
   /v0/account/{account_id}/ft:
     get:
-      description: Retrieve the indexed fungible token contract IDs for an account. This v0 route does not return balances.
+      description: Fetch the fungible token contract IDs an account has held — contract IDs only, no balances.
       operationId: account_ft_v0
       parameters:
       - description: NEAR account ID to inspect.
@@ -355,7 +355,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Account FT
   /v0/account/{account_id}/nft:
     get:
-      description: Fetch the indexed NFT contract IDs associated with an account. This v0 route does not include block-height metadata.
+      description: Fetch the NFT contract IDs an account has held — contract IDs only, no block-height metadata.
       operationId: account_nft_v0
       parameters:
       - description: NEAR account ID to inspect.
@@ -401,7 +401,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Account NFT
   /v0/account/{account_id}/staking:
     get:
-      description: Fetch the staking pool account IDs FastNear has indexed for one account. This v0 route returns pool IDs only, without block-height metadata.
+      description: Fetch staking pool account IDs for one account — pool IDs only, no block-height metadata.
       operationId: account_staking_v0
       parameters:
       - description: NEAR account ID to inspect.
@@ -493,7 +493,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Public Key Lookup
   /v0/public_key/{public_key}/all:
     get:
-      description: Use this variant when one public key may control multiple accounts and you want the full set.
+      description: Fetch every account tied to a public key — full-access and limited-access keys together.
       operationId: lookup_by_public_key_all_v0
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -539,7 +539,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Public Key Lookup (All)
   /v1/account/{account_id}/ft:
     get:
-      description: Fetch the v1 indexed fungible token balance rows for one account.
+      description: Fetch an account's fungible token balance rows, each with contract ID, balance, and last-update block height.
       operationId: account_ft_v1
       parameters:
       - description: NEAR account ID to inspect.
@@ -732,7 +732,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Account Staking
   /v1/ft/{token_id}/top:
     get:
-      description: Use this endpoint to inspect the indexed top holders for a fungible token contract.
+      description: Fetch the top-balance holder list for a fungible token contract, ranked highest balance first.
       operationId: ft_top_v1
       parameters:
       - description: Fungible token contract account ID.
@@ -779,7 +779,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 FT Top Holders
   /v1/public_key/{public_key}:
     get:
-      description: Use the v1 endpoint for the newer namespace. It currently returns the same response shape as the v0 route.
+      description: Fetch the indexed account IDs associated with a full-access public key.
       operationId: lookup_by_public_key_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -825,7 +825,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Public Key Lookup
   /v1/public_key/{public_key}/all:
     get:
-      description: Fetch every indexed account tied to a public key. This v1 route currently uses the same response shape as the v0 route.
+      description: Fetch every account tied to a public key — full-access and limited-access keys together.
       operationId: lookup_by_public_key_all_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -447,7 +447,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Account Staking
   /v0/public_key/{public_key}:
     get:
-      description: Fetch the indexed account IDs associated with a full-access public key.
+      description: Fetch the account IDs that have registered a full-access public key, via the legacy V0 lookup path.
       operationId: lookup_by_public_key_v0
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -493,7 +493,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Public Key Lookup
   /v0/public_key/{public_key}/all:
     get:
-      description: Fetch every account tied to a public key — full-access and limited-access keys together.
+      description: List every account tied to a public key — full-access and limited-access keys together — via the legacy V0 lookup-all path.
       operationId: lookup_by_public_key_all_v0
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -779,7 +779,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 FT Top Holders
   /v1/public_key/{public_key}:
     get:
-      description: Fetch the indexed account IDs associated with a full-access public key.
+      description: Resolve a full-access public key to the indexed NEAR accounts that have registered it — V1 canonical lookup path.
       operationId: lookup_by_public_key_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -825,7 +825,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Public Key Lookup
   /v1/public_key/{public_key}/all:
     get:
-      description: Fetch every account tied to a public key — full-access and limited-access keys together.
+      description: Resolve a public key to every account that holds it — full-access and limited-access keys alike — via the V1 lookup-all path.
       operationId: lookup_by_public_key_all_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -242,7 +242,7 @@ openapi: 3.0.3
 paths:
   /health:
     get:
-      description: Returns `ok` when the service is healthy. When FastNEAR is degraded, the same `status` field carries a diagnostic string instead.
+      description: Use this lightweight probe to confirm the FastNear API is healthy.
       operationId: get_health
       parameters:
       - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
@@ -273,7 +273,7 @@ paths:
       x-fastnear-title: FastNEAR API - Health
   /status:
     get:
-      description: Returns the latest indexed sync heights, the indexed block timestamp, the measured sync latency, and the deployed FastNEAR API version.
+      description: Check the current indexed block height, latency, and deployed service version.
       operationId: get_status
       parameters:
       - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
@@ -308,7 +308,7 @@ paths:
       x-fastnear-title: FastNEAR API - Status
   /v0/account/{account_id}/ft:
     get:
-      description: Returns only fungible token contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include balances or block-height metadata.
+      description: Retrieve the indexed fungible token contract IDs for an account. This v0 route does not return balances.
       operationId: account_ft_v0
       parameters:
       - description: NEAR account ID to inspect.
@@ -355,7 +355,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Account FT
   /v0/account/{account_id}/nft:
     get:
-      description: Returns only NFT contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.
+      description: Fetch the indexed NFT contract IDs associated with an account. This v0 route does not include block-height metadata.
       operationId: account_nft_v0
       parameters:
       - description: NEAR account ID to inspect.
@@ -401,7 +401,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Account NFT
   /v0/account/{account_id}/staking:
     get:
-      description: Returns staking pool account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.
+      description: Fetch the staking pool account IDs FastNear has indexed for one account. This v0 route returns pool IDs only, without block-height metadata.
       operationId: account_staking_v0
       parameters:
       - description: NEAR account ID to inspect.
@@ -447,7 +447,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Account Staking
   /v0/public_key/{public_key}:
     get:
-      description: Returns account IDs currently associated with the provided full-access public key. The response includes account IDs only.
+      description: Fetch the indexed account IDs associated with a full-access public key.
       operationId: lookup_by_public_key_v0
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -493,7 +493,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Public Key Lookup
   /v0/public_key/{public_key}/all:
     get:
-      description: Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index.
+      description: Use this variant when one public key may control multiple accounts and you want the full set.
       operationId: lookup_by_public_key_all_v0
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -539,7 +539,7 @@ paths:
       x-fastnear-title: FastNEAR API - V0 Public Key Lookup (All)
   /v1/account/{account_id}/ft:
     get:
-      description: Returns fungible token rows for the requested account. Balances and `last_update_block_height` remain nullable when the index has not recorded them yet.
+      description: Fetch the v1 indexed fungible token balance rows for one account.
       operationId: account_ft_v1
       parameters:
       - description: NEAR account ID to inspect.
@@ -587,7 +587,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Account FT
   /v1/account/{account_id}/full:
     get:
-      description: Returns staking, fungible token, NFT, and account-state information for the requested account. `state` remains nullable when the account state has not been recorded.
+      description: Fetch the combined indexed account view, including staking pools, FT balances, NFTs, and account state.
       operationId: account_full_v1
       parameters:
       - description: NEAR account ID to inspect.
@@ -638,7 +638,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Account Full
   /v1/account/{account_id}/nft:
     get:
-      description: Returns NFT contract rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that contract relationship.
+      description: Fetch NFT contract rows for an account, including block-height metadata for each contract.
       operationId: account_nft_v1
       parameters:
       - description: NEAR account ID to inspect.
@@ -685,7 +685,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Account NFT
   /v1/account/{account_id}/staking:
     get:
-      description: Returns staking pool rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that pool relationship.
+      description: Retrieve staking pool rows for an account, including block-height metadata for each pool relationship.
       operationId: account_staking_v1
       parameters:
       - description: NEAR account ID to inspect.
@@ -732,7 +732,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Account Staking
   /v1/ft/{token_id}/top:
     get:
-      description: Returns the top indexed accounts by balance for the requested fungible token.
+      description: Use this endpoint to inspect the indexed top holders for a fungible token contract.
       operationId: ft_top_v1
       parameters:
       - description: Fungible token contract account ID.
@@ -779,7 +779,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 FT Top Holders
   /v1/public_key/{public_key}:
     get:
-      description: Returns account IDs currently associated with the supplied full-access public key. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.
+      description: Use the v1 endpoint for the newer namespace. It currently returns the same response shape as the v0 route.
       operationId: lookup_by_public_key_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
@@ -825,7 +825,7 @@ paths:
       x-fastnear-title: FastNEAR API - V1 Public Key Lookup
   /v1/public_key/{public_key}/all:
     get:
-      description: Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.
+      description: Fetch every indexed account tied to a public key. This v1 route currently uses the same response shape as the v0 route.
       operationId: lookup_by_public_key_all_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,878 @@
+components:
+  schemas:
+    AccountBalanceRow:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        balance:
+          nullable: true
+          type: string
+      required:
+      - account_id
+      - balance
+      type: object
+    AccountFullResponse:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        nfts:
+          items:
+            $ref: '#/components/schemas/NftRow'
+          type: array
+        pools:
+          items:
+            $ref: '#/components/schemas/PoolRow'
+          type: array
+        state:
+          allOf:
+          - $ref: '#/components/schemas/AccountStateResponse'
+          nullable: true
+          type: object
+        tokens:
+          items:
+            $ref: '#/components/schemas/TokenRow'
+          type: array
+      required:
+      - account_id
+      - pools
+      - tokens
+      - nfts
+      - state
+      type: object
+    AccountStateResponse:
+      additionalProperties: false
+      properties:
+        balance:
+          nullable: true
+          type: string
+        locked:
+          nullable: true
+          type: string
+        storage_bytes:
+          format: uint64
+          minimum: 0
+          nullable: true
+          type: integer
+      required:
+      - balance
+      - locked
+      - storage_bytes
+      type: object
+    HealthResponse:
+      additionalProperties: false
+      properties:
+        status:
+          type: string
+      required:
+      - status
+      type: object
+    NftRow:
+      additionalProperties: false
+      properties:
+        contract_id:
+          type: string
+        last_update_block_height:
+          format: uint64
+          minimum: 0
+          nullable: true
+          type: integer
+      required:
+      - contract_id
+      - last_update_block_height
+      type: object
+    PoolRow:
+      additionalProperties: false
+      properties:
+        last_update_block_height:
+          format: uint64
+          minimum: 0
+          nullable: true
+          type: integer
+        pool_id:
+          type: string
+      required:
+      - pool_id
+      - last_update_block_height
+      type: object
+    PublicKeyLookupResponse:
+      additionalProperties: false
+      properties:
+        account_ids:
+          items:
+            type: string
+          type: array
+        public_key:
+          type: string
+      required:
+      - public_key
+      - account_ids
+      type: object
+    StatusResponse:
+      additionalProperties: false
+      properties:
+        sync_balance_block_height:
+          format: uint64
+          minimum: 0
+          nullable: true
+          type: integer
+        sync_block_height:
+          format: uint64
+          minimum: 0
+          nullable: true
+          type: integer
+        sync_block_timestamp_nanosec:
+          nullable: true
+          type: string
+        sync_latency_sec:
+          format: double
+          nullable: true
+          type: number
+        version:
+          type: string
+      required:
+      - version
+      - sync_block_height
+      - sync_latency_sec
+      - sync_block_timestamp_nanosec
+      - sync_balance_block_height
+      type: object
+    TokenAccountsResponse:
+      additionalProperties: false
+      properties:
+        accounts:
+          items:
+            $ref: '#/components/schemas/AccountBalanceRow'
+          type: array
+        token_id:
+          type: string
+      required:
+      - token_id
+      - accounts
+      type: object
+    TokenRow:
+      additionalProperties: false
+      properties:
+        balance:
+          nullable: true
+          type: string
+        contract_id:
+          type: string
+        last_update_block_height:
+          format: uint64
+          minimum: 0
+          nullable: true
+          type: integer
+      required:
+      - contract_id
+      - last_update_block_height
+      - balance
+      type: object
+    V0ContractsResponse:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        contract_ids:
+          items:
+            type: string
+          type: array
+      required:
+      - account_id
+      - contract_ids
+      type: object
+    V0StakingResponse:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        pools:
+          items:
+            type: string
+          type: array
+      required:
+      - account_id
+      - pools
+      type: object
+    V1FtResponse:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        tokens:
+          items:
+            $ref: '#/components/schemas/TokenRow'
+          type: array
+      required:
+      - account_id
+      - tokens
+      type: object
+    V1NftResponse:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        tokens:
+          items:
+            $ref: '#/components/schemas/NftRow'
+          type: array
+      required:
+      - account_id
+      - tokens
+      type: object
+    V1StakingResponse:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        pools:
+          items:
+            $ref: '#/components/schemas/PoolRow'
+          type: array
+      required:
+      - account_id
+      - pools
+      type: object
+info:
+  description: Low-latency indexed account, token, and public-key lookup APIs for wallets and explorers. Embedded portal clients may forward an optional `apiKey` query parameter, but the public FastNEAR API does not require it.
+  title: FastNEAR API
+  version: 3.0.3
+openapi: 3.0.3
+paths:
+  /health:
+    get:
+      description: Returns `ok` when the service is healthy. When FastNEAR is degraded, the same `status` field carries a diagnostic string instead.
+      operationId: get_health
+      parameters:
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                status: ok
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+          description: Health status string
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Get service health
+      tags:
+      - system
+      x-fastnear-slug: health
+      x-fastnear-title: FastNEAR API - Health
+  /status:
+    get:
+      description: Returns the latest indexed sync heights, the indexed block timestamp, the measured sync latency, and the deployed FastNEAR API version.
+      operationId: get_status
+      parameters:
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                sync_balance_block_height: 129734103
+                sync_block_height: 129734103
+                sync_block_timestamp_nanosec: '1728256282197171397'
+                sync_latency_sec: 4.671730603
+                version: 0.10.0
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+          description: Current FastNEAR API sync status
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Get service sync status
+      tags:
+      - system
+      x-fastnear-slug: status
+      x-fastnear-title: FastNEAR API - Status
+  /v0/account/{account_id}/ft:
+    get:
+      description: Returns only fungible token contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include balances or block-height metadata.
+      operationId: account_ft_v0
+      parameters:
+      - description: NEAR account ID to inspect.
+        example: here.tg
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_id: here.tg
+                contract_ids:
+                - wrap.near
+                - usdt.tether-token.near
+              schema:
+                $ref: '#/components/schemas/V0ContractsResponse'
+          description: Fungible token contract IDs for the requested account
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup fungible token contract IDs for an account
+      tags:
+      - fungible-tokens
+      x-fastnear-slug: account_ft
+      x-fastnear-title: FastNEAR API - V0 Account FT
+  /v0/account/{account_id}/nft:
+    get:
+      description: Returns only NFT contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.
+      operationId: account_nft_v0
+      parameters:
+      - description: NEAR account ID to inspect.
+        example: sharddog.near
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_id: sharddog.near
+                contract_ids:
+                - nft.example.near
+              schema:
+                $ref: '#/components/schemas/V0ContractsResponse'
+          description: NFT contract IDs for the requested account
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup NFT contract IDs for an account
+      tags:
+      - non-fungible-tokens
+      x-fastnear-slug: account_nft
+      x-fastnear-title: FastNEAR API - V0 Account NFT
+  /v0/account/{account_id}/staking:
+    get:
+      description: Returns staking pool account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.
+      operationId: account_staking_v0
+      parameters:
+      - description: NEAR account ID to inspect.
+        example: mob.near
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_id: mob.near
+                pools:
+                - zavodil.poolv1.near
+              schema:
+                $ref: '#/components/schemas/V0StakingResponse'
+          description: Staking pool account IDs for the requested account
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup staking pool account IDs for an account
+      tags:
+      - staking
+      x-fastnear-slug: account_staking
+      x-fastnear-title: FastNEAR API - V0 Account Staking
+  /v0/public_key/{public_key}:
+    get:
+      description: Returns account IDs currently associated with the provided full-access public key. The response includes account IDs only.
+      operationId: lookup_by_public_key_v0
+      parameters:
+      - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
+        example: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+        in: path
+        name: public_key
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_ids:
+                - example.near
+                public_key: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+              schema:
+                $ref: '#/components/schemas/PublicKeyLookupResponse'
+          description: Matching account IDs for the supplied full-access public key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup full-access accounts by public key
+      tags:
+      - public-key
+      x-fastnear-slug: public_key_lookup
+      x-fastnear-title: FastNEAR API - V0 Public Key Lookup
+  /v0/public_key/{public_key}/all:
+    get:
+      description: Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index.
+      operationId: lookup_by_public_key_all_v0
+      parameters:
+      - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
+        example: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+        in: path
+        name: public_key
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_ids:
+                - example.near
+                - limited.near
+                public_key: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+              schema:
+                $ref: '#/components/schemas/PublicKeyLookupResponse'
+          description: Matching account IDs for the supplied public key, including limited-access keys
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup all indexed accounts by public key
+      tags:
+      - public-key
+      x-fastnear-slug: public_key_lookup_all
+      x-fastnear-title: FastNEAR API - V0 Public Key Lookup (All)
+  /v1/account/{account_id}/ft:
+    get:
+      description: Returns fungible token rows for the requested account. Balances and `last_update_block_height` remain nullable when the index has not recorded them yet.
+      operationId: account_ft_v1
+      parameters:
+      - description: NEAR account ID to inspect.
+        example: here.tg
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_id: here.tg
+                tokens:
+                - balance: '1000000000000000000000000'
+                  contract_id: wrap.near
+                  last_update_block_height: null
+              schema:
+                $ref: '#/components/schemas/V1FtResponse'
+          description: Indexed fungible token rows for the requested account
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup indexed fungible token rows for an account
+      tags:
+      - fungible-tokens
+      x-fastnear-slug: account_ft
+      x-fastnear-title: FastNEAR API - V1 Account FT
+  /v1/account/{account_id}/full:
+    get:
+      description: Returns staking, fungible token, NFT, and account-state information for the requested account. `state` remains nullable when the account state has not been recorded.
+      operationId: account_full_v1
+      parameters:
+      - description: NEAR account ID to inspect.
+        example: here.tg
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_id: here.tg
+                nfts: []
+                pools: []
+                state:
+                  balance: '1000000000000000000000000'
+                  locked: '0'
+                  storage_bytes: 512
+                tokens: []
+              schema:
+                $ref: '#/components/schemas/AccountFullResponse'
+          description: Full indexed account information for the requested account
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup full indexed account information
+      tags:
+      - accounts
+      x-fastnear-slug: account_full
+      x-fastnear-title: FastNEAR API - V1 Account Full
+  /v1/account/{account_id}/nft:
+    get:
+      description: Returns NFT contract rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that contract relationship.
+      operationId: account_nft_v1
+      parameters:
+      - description: NEAR account ID to inspect.
+        example: sharddog.near
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_id: sharddog.near
+                tokens:
+                - contract_id: nft.example.near
+                  last_update_block_height: null
+              schema:
+                $ref: '#/components/schemas/V1NftResponse'
+          description: Indexed NFT contract rows for the requested account
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup indexed NFT contract rows for an account
+      tags:
+      - non-fungible-tokens
+      x-fastnear-slug: account_nft
+      x-fastnear-title: FastNEAR API - V1 Account NFT
+  /v1/account/{account_id}/staking:
+    get:
+      description: Returns staking pool rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that pool relationship.
+      operationId: account_staking_v1
+      parameters:
+      - description: NEAR account ID to inspect.
+        example: mob.near
+        in: path
+        name: account_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_id: mob.near
+                pools:
+                - last_update_block_height: null
+                  pool_id: zavodil.poolv1.near
+              schema:
+                $ref: '#/components/schemas/V1StakingResponse'
+          description: Indexed staking pool rows for the requested account
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup indexed staking pools for an account
+      tags:
+      - staking
+      x-fastnear-slug: account_staking
+      x-fastnear-title: FastNEAR API - V1 Account Staking
+  /v1/ft/{token_id}/top:
+    get:
+      description: Returns the top indexed accounts by balance for the requested fungible token.
+      operationId: ft_top_v1
+      parameters:
+      - description: Fungible token contract account ID.
+        example: wrap.near
+        in: path
+        name: token_id
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                accounts:
+                - account_id: mob.near
+                  balance: '979894691374420631019486155'
+                token_id: wrap.near
+              schema:
+                $ref: '#/components/schemas/TokenAccountsResponse'
+          description: Indexed top holders for the requested fungible token
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup top indexed holders for a fungible token
+      tags:
+      - fungible-tokens
+      x-fastnear-slug: ft_top
+      x-fastnear-title: FastNEAR API - V1 FT Top Holders
+  /v1/public_key/{public_key}:
+    get:
+      description: Returns account IDs currently associated with the supplied full-access public key. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.
+      operationId: lookup_by_public_key_v1
+      parameters:
+      - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
+        example: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+        in: path
+        name: public_key
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_ids:
+                - example.near
+                public_key: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+              schema:
+                $ref: '#/components/schemas/PublicKeyLookupResponse'
+          description: Matching account IDs for the supplied full-access public key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup full-access accounts by public key
+      tags:
+      - public-key
+      x-fastnear-slug: public_key_lookup
+      x-fastnear-title: FastNEAR API - V1 Public Key Lookup
+  /v1/public_key/{public_key}/all:
+    get:
+      description: Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.
+      operationId: lookup_by_public_key_all_v1
+      parameters:
+      - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
+        example: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+        in: path
+        name: public_key
+        required: true
+        schema:
+          type: string
+      - description: Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                account_ids:
+                - example.near
+                - limited.near
+                public_key: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+              schema:
+                $ref: '#/components/schemas/PublicKeyLookupResponse'
+          description: Matching account IDs for the supplied public key, including limited-access keys
+        '400':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Lookup all indexed accounts by public key
+      tags:
+      - public-key
+      x-fastnear-slug: public_key_lookup_all
+      x-fastnear-title: FastNEAR API - V1 Public Key Lookup (All)
+servers:
+- description: Mainnet
+  url: https://api.fastnear.com
+- description: Testnet
+  url: https://test.api.fastnear.com

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -451,7 +451,7 @@ paths:
       operationId: lookup_by_public_key_v0
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
-        example: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+        example: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
         in: path
         name: public_key
         required: true
@@ -469,8 +469,8 @@ paths:
             application/json:
               example:
                 account_ids:
-                - example.near
-                public_key: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+                - root.near
+                public_key: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
               schema:
                 $ref: '#/components/schemas/PublicKeyLookupResponse'
           description: Matching account IDs for the supplied full-access public key
@@ -497,7 +497,7 @@ paths:
       operationId: lookup_by_public_key_all_v0
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
-        example: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+        example: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
         in: path
         name: public_key
         required: true
@@ -515,9 +515,8 @@ paths:
             application/json:
               example:
                 account_ids:
-                - example.near
-                - limited.near
-                public_key: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+                - root.near
+                public_key: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
               schema:
                 $ref: '#/components/schemas/PublicKeyLookupResponse'
           description: Matching account IDs for the supplied public key, including limited-access keys
@@ -784,7 +783,7 @@ paths:
       operationId: lookup_by_public_key_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
-        example: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+        example: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
         in: path
         name: public_key
         required: true
@@ -802,8 +801,8 @@ paths:
             application/json:
               example:
                 account_ids:
-                - example.near
-                public_key: ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3
+                - root.near
+                public_key: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
               schema:
                 $ref: '#/components/schemas/PublicKeyLookupResponse'
           description: Matching account IDs for the supplied full-access public key
@@ -830,7 +829,7 @@ paths:
       operationId: lookup_by_public_key_all_v1
       parameters:
       - description: NEAR public key in `ed25519:...` or `secp256k1:...` form.
-        example: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+        example: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
         in: path
         name: public_key
         required: true
@@ -848,9 +847,8 @@ paths:
             application/json:
               example:
                 account_ids:
-                - example.near
-                - limited.near
-                public_key: ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd
+                - root.near
+                public_key: ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT
               schema:
                 $ref: '#/components/schemas/PublicKeyLookupResponse'
           description: Matching account IDs for the supplied public key, including limited-access keys

--- a/skill.md
+++ b/skill.md
@@ -15,7 +15,7 @@ Base URLs:
 
 ### API V1 (recommended)
 
-- `GET /v1/public_key/{public_key}` — Full-access public key to account ID(s). Also returns the implicit account ID.
+- `GET /v1/public_key/{public_key}` — Full-access public key to account ID(s).
 - `GET /v1/public_key/{public_key}/all` — Any public key (including limited access) to account ID(s).
 - `GET /v1/account/{account_id}/staking` — Delegated staking pools with `last_update_block_height`.
 - `GET /v1/account/{account_id}/ft` — Fungible tokens with `last_update_block_height` and `balance`.
@@ -36,4 +36,4 @@ Base URLs:
 - `balance` is a decimal integer string (not adjusted for token decimals).
 - `balance: null` means balance is not yet available; `balance: ""` means the FT contract may be broken.
 - `last_update_block_height: null` means no recent updates were recorded (tracking started around block 115000000).
-- Public key endpoints also return the implicit account ID, even if it doesn't exist on-chain.
+- `v1/public_key/*` currently uses the same `{ public_key, account_ids }` response shape as `v0/public_key/*`.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,15 +1,18 @@
-use crate::*;
-use actix_web::ResponseError;
-use near_account_id::AccountId;
-use near_crypto::PublicKey;
-use serde_json::json;
-use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
-const TARGET_API: &str = "api";
+use actix_web::{get, web, HttpRequest, HttpResponse, Responder, ResponseError};
+use near_account_id::AccountId;
+use near_crypto::PublicKey;
 
-pub type BlockHeight = u64;
+use crate::types::{
+    parse_account_state, AccountBalanceRow, AccountFullResponse, ExpFtWithBalancesResponse, NftRow,
+    PoolRow, PublicKeyLookupResponse, TokenAccountsResponse, TokenRow, V0ContractsResponse,
+    V0StakingResponse, V1FtResponse, V1NftResponse, V1StakingResponse,
+};
+use crate::{database, rpc, AppState};
+
+const TARGET_API: &str = "api";
 
 #[derive(Debug)]
 pub enum ServiceError {
@@ -72,9 +75,10 @@ impl ResponseError for ServiceError {
                 tracing::info!(target: TARGET_API, "Service error: {}", self);
                 HttpResponse::BadRequest().json("Invalid argument")
             }
-            ServiceError::RpcError(ref e) => {
+            ServiceError::RpcError(ref error) => {
                 tracing::error!(target: TARGET_API, "Service error: {}", self);
-                HttpResponse::InternalServerError().json(format!("Internal server error {:?}", e))
+                HttpResponse::InternalServerError()
+                    .json(format!("Internal server error {:?}", error))
             }
         }
     }
@@ -91,7 +95,11 @@ pub mod v0 {
         let public_key = PublicKey::from_str(request.match_info().get("public_key").unwrap())
             .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up account_ids for public_key: {}", public_key);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up account_ids for public_key: {}",
+            public_key
+        );
 
         let mut connection = app_state
             .redis_client
@@ -99,17 +107,22 @@ pub mod v0 {
             .await?;
 
         let public_key = public_key.to_string();
+        let account_ids = database::query_with_prefix(&mut connection, "pk", &public_key)
+            .await?
+            .into_iter()
+            .filter_map(|(account_id, access_kind)| {
+                if access_kind == "f" {
+                    Some(account_id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
 
-        let account_ids = database::query_with_prefix(&mut connection, "pk", &public_key).await?;
-
-        Ok(web::Json(json!({
-            "public_key": public_key,
-            "account_ids": account_ids.into_iter().filter_map(|(k, v)| if v == "f" {
-                Some(k)
-            } else {
-                None
-            }).collect::<Vec<_>>(),
-        })))
+        Ok(web::Json(PublicKeyLookupResponse {
+            public_key,
+            account_ids,
+        }))
     }
 
     #[get("/public_key/{public_key}/all")]
@@ -120,7 +133,11 @@ pub mod v0 {
         let public_key = PublicKey::from_str(request.match_info().get("public_key").unwrap())
             .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up account_ids for all public_key: {}", public_key);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up account_ids for all public_key: {}",
+            public_key
+        );
 
         let mut connection = app_state
             .redis_client
@@ -128,13 +145,16 @@ pub mod v0 {
             .await?;
 
         let public_key = public_key.to_string();
+        let account_ids = database::query_with_prefix(&mut connection, "pk", &public_key)
+            .await?
+            .into_iter()
+            .map(|(account_id, _)| account_id)
+            .collect::<Vec<_>>();
 
-        let account_ids = database::query_with_prefix(&mut connection, "pk", &public_key).await?;
-
-        Ok(web::Json(json!({
-            "public_key": public_key,
-            "account_ids": account_ids.into_iter().map(|(k, _v)| k).collect::<Vec<_>>(),
-        })))
+        Ok(web::Json(PublicKeyLookupResponse {
+            public_key,
+            account_ids,
+        }))
     }
 
     #[get("/account/{account_id}/staking")]
@@ -146,20 +166,25 @@ pub mod v0 {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up validators for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up validators for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
             .get_multiplexed_async_connection()
             .await?;
 
-        let query_result =
-            database::query_with_prefix(&mut connection, "st", &account_id.to_string()).await?;
+        let account_id = account_id.to_string();
+        let pools = database::query_with_prefix(&mut connection, "st", &account_id)
+            .await?
+            .into_iter()
+            .map(|(pool_id, _)| pool_id)
+            .collect();
 
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "pools": query_result.into_iter().map(|(k, _v)| k).collect::<Vec<String>>(),
-        })))
+        Ok(web::Json(V0StakingResponse { account_id, pools }))
     }
 
     #[get("/account/{account_id}/ft")]
@@ -171,20 +196,28 @@ pub mod v0 {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up fungible tokens for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up fungible tokens for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
             .get_multiplexed_async_connection()
             .await?;
 
-        let query_result =
-            database::query_with_prefix(&mut connection, "ft", &account_id.to_string()).await?;
+        let account_id = account_id.to_string();
+        let contract_ids = database::query_with_prefix(&mut connection, "ft", &account_id)
+            .await?
+            .into_iter()
+            .map(|(contract_id, _)| contract_id)
+            .collect();
 
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "contract_ids": query_result.into_iter().map(|(k, _v)| k).collect::<Vec<String>>(),
-        })))
+        Ok(web::Json(V0ContractsResponse {
+            account_id,
+            contract_ids,
+        }))
     }
 
     #[get("/account/{account_id}/nft")]
@@ -196,20 +229,28 @@ pub mod v0 {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up non-fungible tokens for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up non-fungible tokens for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
             .get_multiplexed_async_connection()
             .await?;
 
-        let query_result =
-            database::query_with_prefix(&mut connection, "nf", &account_id.to_string()).await?;
+        let account_id = account_id.to_string();
+        let contract_ids = database::query_with_prefix(&mut connection, "nf", &account_id)
+            .await?
+            .into_iter()
+            .map(|(contract_id, _)| contract_id)
+            .collect();
 
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "contract_ids": query_result.into_iter().map(|(k, _v)| k).collect::<Vec<String>>(),
-        })))
+        Ok(web::Json(V0ContractsResponse {
+            account_id,
+            contract_ids,
+        }))
     }
 }
 
@@ -225,7 +266,11 @@ pub mod exp {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up fungible tokens for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up fungible tokens for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
@@ -233,17 +278,14 @@ pub mod exp {
             .await?;
 
         let account_id = account_id.to_string();
-
         let token_ids =
             database::query_with_prefix_parse(&mut connection, "ft", &account_id).await?;
+        let token_balances = rpc::get_ft_balances(&account_id, &token_ids).await?;
 
-        let token_balances: HashMap<String, Option<String>> =
-            rpc::get_ft_balances(&account_id, &token_ids).await?;
-
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "tokens": token_balances,
-        })))
+        Ok(web::Json(ExpFtWithBalancesResponse {
+            account_id,
+            tokens: token_balances,
+        }))
     }
 
     #[get("/ft/{token_id}/all")]
@@ -255,7 +297,11 @@ pub mod exp {
             AccountId::try_from(request.match_info().get("token_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Retrieving all holders for token: {}", token_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Retrieving all holders for token: {}",
+            token_id
+        );
 
         let mut connection = app_state
             .redis_client
@@ -263,17 +309,16 @@ pub mod exp {
             .await?;
 
         let token_id = token_id.to_string();
+        let accounts = database::query_with_prefix(&mut connection, "b", &token_id)
+            .await?
+            .into_iter()
+            .map(|(account_id, balance)| AccountBalanceRow {
+                account_id,
+                balance: Some(balance),
+            })
+            .collect();
 
-        let tokens_with_balances =
-            database::query_with_prefix(&mut connection, "b", &token_id).await?;
-
-        Ok(web::Json(json!({
-            "token_id": token_id,
-            "accounts": tokens_with_balances.into_iter().map(|(account_id, balance)| json!({
-                "account_id": account_id,
-                "balance": balance,
-            })).collect::<Vec<_>>()
-        })))
+        Ok(web::Json(TokenAccountsResponse { token_id, accounts }))
     }
 }
 
@@ -289,24 +334,28 @@ pub mod v1 {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up validators for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up validators for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
             .get_multiplexed_async_connection()
             .await?;
 
-        let query_result =
-            database::query_with_prefix_parse(&mut connection, "st", &account_id.to_string())
-                .await?;
+        let account_id = account_id.to_string();
+        let pools = database::query_with_prefix_parse(&mut connection, "st", &account_id)
+            .await?
+            .into_iter()
+            .map(|(pool_id, last_update_block_height)| PoolRow {
+                pool_id,
+                last_update_block_height,
+            })
+            .collect();
 
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "pools": query_result.into_iter().map(|(pool_id, last_update_block_height)| json!({
-                "pool_id": pool_id,
-                "last_update_block_height": last_update_block_height,
-            })).collect::<Vec<_>>()
-        })))
+        Ok(web::Json(V1StakingResponse { account_id, pools }))
     }
 
     #[get("/account/{account_id}/ft")]
@@ -318,7 +367,11 @@ pub mod v1 {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up fungible tokens for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up fungible tokens for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
@@ -326,7 +379,6 @@ pub mod v1 {
             .await?;
 
         let account_id = account_id.to_string();
-
         let query_result =
             database::query_with_prefix_parse(&mut connection, "ft", &account_id).await?;
         let balances = database::query_balances(
@@ -338,15 +390,19 @@ pub mod v1 {
                 .as_slice(),
         )
         .await?;
+        let tokens = query_result
+            .into_iter()
+            .zip(balances.into_iter())
+            .map(
+                |((contract_id, last_update_block_height), balance)| TokenRow {
+                    contract_id,
+                    last_update_block_height,
+                    balance,
+                },
+            )
+            .collect();
 
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "tokens": query_result.into_iter().zip(balances.into_iter()).map(|((contract_id, last_update_block_height), balance)| json!({
-                "contract_id": contract_id,
-                "last_update_block_height": last_update_block_height,
-                "balance": balance,
-            })).collect::<Vec<_>>()
-        })))
+        Ok(web::Json(V1FtResponse { account_id, tokens }))
     }
 
     #[get("/account/{account_id}/nft")]
@@ -358,24 +414,28 @@ pub mod v1 {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking up non-fungible tokens for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking up non-fungible tokens for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
             .get_multiplexed_async_connection()
             .await?;
 
-        let query_result =
-            database::query_with_prefix_parse(&mut connection, "nf", &account_id.to_string())
-                .await?;
+        let account_id = account_id.to_string();
+        let tokens = database::query_with_prefix_parse(&mut connection, "nf", &account_id)
+            .await?
+            .into_iter()
+            .map(|(contract_id, last_update_block_height)| NftRow {
+                contract_id,
+                last_update_block_height,
+            })
+            .collect();
 
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "tokens": query_result.into_iter().map(|(contract_id, last_update_block_height)| json!({
-                "contract_id": contract_id,
-                "last_update_block_height": last_update_block_height,
-            })).collect::<Vec<_>>()
-        })))
+        Ok(web::Json(V1NftResponse { account_id, tokens }))
     }
 
     #[get("/ft/{token_id}/top")]
@@ -387,7 +447,11 @@ pub mod v1 {
             AccountId::try_from(request.match_info().get("token_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Retrieving top holders for token: {}", token_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Retrieving top holders for token: {}",
+            token_id
+        );
 
         let mut connection = app_state
             .redis_client
@@ -395,7 +459,6 @@ pub mod v1 {
             .await?;
 
         let token_id = token_id.to_string();
-
         let query_result =
             database::query_zset_by_score(&mut connection, &format!("tb:{}", token_id), 100)
                 .await?;
@@ -417,25 +480,27 @@ pub mod v1 {
         top_holders.sort_unstable_by(|a, b| {
             (
                 b.1.as_ref()
-                    .and_then(|b| b.parse::<u128>().ok())
+                    .and_then(|balance| balance.parse::<u128>().ok())
                     .unwrap_or(0),
                 &b.0,
             )
                 .cmp(&(
                     a.1.as_ref()
-                        .and_then(|b| b.parse::<u128>().ok())
+                        .and_then(|balance| balance.parse::<u128>().ok())
                         .unwrap_or(0),
                     &a.0,
                 ))
         });
 
-        Ok(web::Json(json!({
-            "token_id": token_id,
-            "accounts": top_holders.iter().map(|(account_id, balance)| json!({
-                "account_id": account_id,
-                "balance": balance,
-            })).collect::<Vec<_>>()
-        })))
+        let accounts = top_holders
+            .into_iter()
+            .map(|(account_id, balance)| AccountBalanceRow {
+                account_id,
+                balance,
+            })
+            .collect();
+
+        Ok(web::Json(TokenAccountsResponse { token_id, accounts }))
     }
 
     #[get("/account/{account_id}/full")]
@@ -447,7 +512,11 @@ pub mod v1 {
             AccountId::try_from(request.match_info().get("account_id").unwrap().to_string())
                 .map_err(|_| ServiceError::ArgumentError)?;
 
-        tracing::debug!(target: TARGET_API, "Looking full data for account_id: {}", account_id);
+        tracing::debug!(
+            target: TARGET_API,
+            "Looking full data for account_id: {}",
+            account_id
+        );
 
         let mut connection = app_state
             .redis_client
@@ -456,17 +525,12 @@ pub mod v1 {
 
         let account_id = account_id.to_string();
 
-        let query_result =
-            database::query_with_prefix_parse(&mut connection, "st", &account_id.to_string())
-                .await?;
-
-        let pools = query_result
+        let pools = database::query_with_prefix_parse(&mut connection, "st", &account_id)
+            .await?
             .into_iter()
-            .map(|(pool_id, last_update_block_height)| {
-                json!({
-                    "pool_id": pool_id,
-                    "last_update_block_height": last_update_block_height,
-                })
+            .map(|(pool_id, last_update_block_height)| PoolRow {
+                pool_id,
+                last_update_block_height,
             })
             .collect::<Vec<_>>();
 
@@ -484,49 +548,34 @@ pub mod v1 {
         let tokens = query_result
             .into_iter()
             .zip(balances.into_iter())
-            .map(|((contract_id, last_update_block_height), balance)| {
-                json!({
-                    "contract_id": contract_id,
-                    "last_update_block_height": last_update_block_height,
-                    "balance": balance,
-                })
-            })
+            .map(
+                |((contract_id, last_update_block_height), balance)| TokenRow {
+                    contract_id,
+                    last_update_block_height,
+                    balance,
+                },
+            )
             .collect::<Vec<_>>();
 
-        let query_result =
-            database::query_with_prefix_parse(&mut connection, "nf", &account_id.to_string())
-                .await?;
-
-        let nfts = query_result
-            .into_iter()
-            .map(|(contract_id, last_update_block_height)| {
-                json!({
-                    "contract_id": contract_id,
-                    "last_update_block_height": last_update_block_height,
-                })
-            })
-            .collect::<Vec<_>>();
-
-        let state = database::query_hget(&mut connection, "accounts", &account_id)
+        let nfts = database::query_with_prefix_parse(&mut connection, "nf", &account_id)
             .await?
-            .and_then(|state| {
-                if state.is_empty() {
-                    None
-                } else {
-                    serde_json::from_str::<serde_json::Value>(&state).ok()
-                }
-            });
+            .into_iter()
+            .map(|(contract_id, last_update_block_height)| NftRow {
+                contract_id,
+                last_update_block_height,
+            })
+            .collect::<Vec<_>>();
 
-        Ok(web::Json(json!({
-            "account_id": account_id,
-            "pools": pools,
-            "tokens": tokens,
-            "nfts": nfts,
-            "state": state.map(|state| json!({
-                "balance": state["b"],
-                "locked": state["l"],
-                "storage_bytes": state["s"],
-            })),
-        })))
+        let state = parse_account_state(
+            database::query_hget(&mut connection, "accounts", &account_id).await?,
+        );
+
+        Ok(web::Json(AccountFullResponse {
+            account_id,
+            pools,
+            tokens,
+            nfts,
+            state,
+        }))
     }
 }

--- a/src/bin/generate-openapi.rs
+++ b/src/bin/generate-openapi.rs
@@ -1,0 +1,21 @@
+#[cfg(feature = "openapi")]
+fn main() -> anyhow::Result<()> {
+    let mut check = false;
+    let mut include_exp = false;
+
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--check" => check = true,
+            "--include-exp" => include_exp = true,
+            other => anyhow::bail!("Unsupported argument: {other}"),
+        }
+    }
+
+    fastnear_api_server_rs::openapi::generate(check, include_exp)
+}
+
+#[cfg(not(feature = "openapi"))]
+fn main() {
+    eprintln!("This binary requires the `openapi` feature.");
+    std::process::exit(1);
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,4 +1,4 @@
-use crate::api::BlockHeight;
+use crate::types::BlockHeight;
 
 const TARGET_DB: &str = "database";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,69 @@
+pub mod api;
+pub mod database;
+#[cfg(feature = "openapi")]
+pub mod openapi;
+pub mod redis_db;
+pub mod rpc;
+pub mod status;
+pub mod types;
+
+use actix_web::{web, HttpResponse, Responder, Scope};
+
+#[derive(Clone)]
+pub struct Config {
+    pub max_healthy_latency_sec: f64,
+    pub max_healthy_sync_block_diff: u64,
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub redis_client: redis::Client,
+    pub config: Config,
+}
+
+const INDEX_HTML: &str = include_str!("../index.html");
+const SKILL_MD: &str = include_str!("../skill.md");
+
+pub async fn index_html() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(INDEX_HTML)
+}
+
+pub async fn skill_md() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/markdown; charset=utf-8")
+        .body(SKILL_MD)
+}
+
+pub fn api_v0_scope() -> Scope {
+    web::scope("/v0")
+        .service(api::v0::lookup_by_public_key)
+        .service(api::v0::lookup_by_public_key_all)
+        .service(api::v0::staking)
+        .service(api::v0::ft)
+        .service(api::v0::nft)
+}
+
+pub fn api_v1_scope() -> Scope {
+    web::scope("/v1")
+        .service(api::v0::lookup_by_public_key)
+        .service(api::v0::lookup_by_public_key_all)
+        .service(api::v1::staking)
+        .service(api::v1::ft)
+        .service(api::v1::nft)
+        .service(api::v1::ft_top)
+        .service(api::v1::account_full)
+}
+
+pub fn api_exp_scope(enable_experimental: bool) -> Scope {
+    let mut scope = web::scope("/exp");
+
+    if enable_experimental {
+        scope = scope
+            .service(api::exp::ft_with_balances)
+            .service(api::exp::ft_all);
+    }
+
+    scope
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,44 +1,13 @@
-mod api;
-mod database;
-mod redis_db;
-mod rpc;
-mod status;
-
-use dotenv::dotenv;
 use std::env;
 
 use actix_cors::Cors;
 use actix_web::http::header;
-use actix_web::{get, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use actix_web::{middleware, web, App, HttpServer};
+use dotenv::dotenv;
+use fastnear_api_server_rs::{
+    api_exp_scope, api_v0_scope, api_v1_scope, index_html, skill_md, status, AppState, Config,
+};
 use tracing_subscriber::EnvFilter;
-
-#[derive(Clone)]
-pub struct Config {
-    pub max_healthy_latency_sec: f64,
-    pub max_healthy_sync_block_diff: u64,
-}
-
-#[derive(Clone)]
-pub struct AppState {
-    pub redis_client: redis::Client,
-    pub config: Config,
-}
-
-const INDEX_HTML: &str = include_str!("../index.html");
-
-async fn index_html() -> impl Responder {
-    HttpResponse::Ok()
-        .content_type("text/html; charset=utf-8")
-        .body(INDEX_HTML)
-}
-
-const SKILL_MD: &str = include_str!("../skill.md");
-
-async fn skill_md() -> impl Responder {
-    HttpResponse::Ok()
-        .content_type("text/markdown; charset=utf-8")
-        .body(SKILL_MD)
-}
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -47,7 +16,6 @@ async fn main() -> std::io::Result<()> {
 
     tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
-        // .with_env_filter(EnvFilter::new("debug"))
         .with_writer(std::io::stderr)
         .init();
 
@@ -57,21 +25,24 @@ async fn main() -> std::io::Result<()> {
 
     let config = Config {
         max_healthy_latency_sec: env::var("MAX_HEALTHY_SYNC_LATENCY_SEC")
-            .map(|s| {
-                s.parse()
+            .map(|value| {
+                value
+                    .parse()
                     .expect("Failed to parse MAX_HEALTHY_SYNC_LATENCY_SEC")
             })
             .unwrap_or(10.0),
         max_healthy_sync_block_diff: env::var("MAX_HEALTHY_SYNC_BLOCK_DIFF")
-            .map(|s| {
-                s.parse()
+            .map(|value| {
+                value
+                    .parse()
                     .expect("Failed to parse MAX_HEALTHY_SYNC_BLOCK_DIFF")
             })
             .unwrap_or(3),
     };
 
+    let enable_experimental = env::var("EXPERIMENTAL_API").ok() == Some("true".to_string());
+
     HttpServer::new(move || {
-        // Configure CORS middleware
         let cors = Cors::default()
             .allow_any_origin()
             .allowed_methods(vec!["GET", "POST"])
@@ -83,30 +54,6 @@ async fn main() -> std::io::Result<()> {
             .max_age(3600)
             .supports_credentials();
 
-        let api_v0 = web::scope("/v0")
-            .service(api::v0::lookup_by_public_key)
-            .service(api::v0::lookup_by_public_key_all)
-            .service(api::v0::staking)
-            .service(api::v0::ft)
-            .service(api::v0::nft);
-
-        let mut api_exp = web::scope("/exp");
-
-        if env::var("EXPERIMENTAL_API").ok() == Some("true".to_string()) {
-            api_exp = api_exp
-                .service(api::exp::ft_with_balances)
-                .service(api::exp::ft_all);
-        }
-
-        let api_v1 = web::scope("/v1")
-            .service(api::v0::lookup_by_public_key)
-            .service(api::v0::lookup_by_public_key_all)
-            .service(api::v1::staking)
-            .service(api::v1::ft)
-            .service(api::v1::nft)
-            .service(api::v1::ft_top)
-            .service(api::v1::account_full);
-
         App::new()
             .app_data(web::Data::new(AppState {
                 redis_client: redis_client.clone(),
@@ -114,12 +61,12 @@ async fn main() -> std::io::Result<()> {
             }))
             .wrap(cors)
             .wrap(middleware::Logger::new(
-                "%{r}a \"%r\"	%s %b \"%{Referer}i\" \"%{User-Agent}i\" %T",
+                "%{r}a \"%r\"\t%s %b \"%{Referer}i\" \"%{User-Agent}i\" %T",
             ))
             .wrap(tracing_actix_web::TracingLogger::default())
-            .service(api_v0)
-            .service(api_exp)
-            .service(api_v1)
+            .service(api_v0_scope())
+            .service(api_exp_scope(enable_experimental))
+            .service(api_v1_scope())
             .service(status::status)
             .service(status::health)
             .route("/index.html", web::get().to(index_html))

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -75,7 +75,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/public_key/{public_key}",
             "lookup_by_public_key_v0",
             "Lookup full-access accounts by public key",
-            "Fetch the indexed account IDs associated with a full-access public key.",
+            "Fetch the account IDs that have registered a full-access public key, via the legacy V0 lookup path.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -96,7 +96,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/public_key/{public_key}/all",
             "lookup_by_public_key_all_v0",
             "Lookup all indexed accounts by public key",
-            "Fetch every account tied to a public key — full-access and limited-access keys together.",
+            "List every account tied to a public key — full-access and limited-access keys together — via the legacy V0 lookup-all path.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -180,7 +180,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/public_key/{public_key}",
             "lookup_by_public_key_v1",
             "Lookup full-access accounts by public key",
-            "Fetch the indexed account IDs associated with a full-access public key.",
+            "Resolve a full-access public key to the indexed NEAR accounts that have registered it — V1 canonical lookup path.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -201,7 +201,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/public_key/{public_key}/all",
             "lookup_by_public_key_all_v1",
             "Lookup all indexed accounts by public key",
-            "Fetch every account tied to a public key — full-access and limited-access keys together.",
+            "Resolve a public key to every account that holds it — full-access and limited-access keys alike — via the V1 lookup-all path.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,0 +1,670 @@
+use anyhow::Result;
+use fastnear_openapi_generator::{
+    build_service_doc, write_or_check_yaml, AggregateOperationSpec, ApiInfo, ApiServer,
+    HttpMethod, ParameterLocation, ParameterSpec, ResponseContent, ResponseSpec, SchemaRegistry,
+};
+use schemars::JsonSchema;
+use serde_json::{json, Value};
+
+use crate::types::{
+    AccountFullResponse, ExpFtWithBalancesResponse, HealthResponse, PublicKeyLookupResponse,
+    StatusResponse, TokenAccountsResponse, V0ContractsResponse, V0StakingResponse, V1FtResponse,
+    V1NftResponse, V1StakingResponse,
+};
+
+const API_VERSION: &str = "3.0.3";
+const SERVICE_INFO: ApiInfo<'static> = ApiInfo {
+    title: "FastNEAR API",
+    version: API_VERSION,
+    description: "Low-latency indexed account, token, and public-key lookup APIs for wallets and explorers. Embedded portal clients may forward an optional `apiKey` query parameter, but the public FastNEAR API does not require it.",
+    servers: &[
+        ApiServer {
+            url: "https://api.fastnear.com",
+            description: "Mainnet",
+        },
+        ApiServer {
+            url: "https://test.api.fastnear.com",
+            description: "Testnet",
+        },
+    ],
+};
+
+pub fn generate(check: bool, include_exp: bool) -> Result<()> {
+    let output_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("openapi");
+    let mut registry = SchemaRegistry::openapi3();
+
+    let mut operations = vec![
+        get_operation_spec::<StatusResponse>(
+            &mut registry,
+            "status",
+            "FastNEAR API - Status",
+            "/status",
+            "get_status",
+            "Get service sync status",
+            "Returns the latest indexed sync heights, the indexed block timestamp, the measured sync latency, and the deployed FastNEAR API version.",
+            &["system"],
+            vec![api_key_parameter()],
+            "Current FastNEAR API sync status",
+            Some(json!({
+                "sync_balance_block_height": 129734103,
+                "sync_block_height": 129734103,
+                "sync_block_timestamp_nanosec": "1728256282197171397",
+                "sync_latency_sec": 4.671730603,
+                "version": "0.10.0"
+            })),
+            false,
+        ),
+        get_operation_spec::<HealthResponse>(
+            &mut registry,
+            "health",
+            "FastNEAR API - Health",
+            "/health",
+            "get_health",
+            "Get service health",
+            "Returns `ok` when the service is healthy. When FastNEAR is degraded, the same `status` field carries a diagnostic string instead.",
+            &["system"],
+            vec![api_key_parameter()],
+            "Health status string",
+            Some(json!({ "status": "ok" })),
+            false,
+        ),
+        get_operation_spec::<PublicKeyLookupResponse>(
+            &mut registry,
+            "public_key_lookup",
+            "FastNEAR API - V0 Public Key Lookup",
+            "/v0/public_key/{public_key}",
+            "lookup_by_public_key_v0",
+            "Lookup full-access accounts by public key",
+            "Returns account IDs currently associated with the provided full-access public key. The response includes account IDs only.",
+            &["public-key"],
+            with_api_key(vec![path_parameter(
+                "public_key",
+                "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
+                json!("ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3"),
+            )]),
+            "Matching account IDs for the supplied full-access public key",
+            Some(json!({
+                "public_key": "ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3",
+                "account_ids": ["example.near"]
+            })),
+            true,
+        ),
+        get_operation_spec::<PublicKeyLookupResponse>(
+            &mut registry,
+            "public_key_lookup_all",
+            "FastNEAR API - V0 Public Key Lookup (All)",
+            "/v0/public_key/{public_key}/all",
+            "lookup_by_public_key_all_v0",
+            "Lookup all indexed accounts by public key",
+            "Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index.",
+            &["public-key"],
+            with_api_key(vec![path_parameter(
+                "public_key",
+                "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
+                json!("ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd"),
+            )]),
+            "Matching account IDs for the supplied public key, including limited-access keys",
+            Some(json!({
+                "public_key": "ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd",
+                "account_ids": ["example.near", "limited.near"]
+            })),
+            true,
+        ),
+        get_operation_spec::<V0StakingResponse>(
+            &mut registry,
+            "account_staking",
+            "FastNEAR API - V0 Account Staking",
+            "/v0/account/{account_id}/staking",
+            "account_staking_v0",
+            "Lookup staking pool account IDs for an account",
+            "Returns staking pool account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.",
+            &["staking"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("mob.near"),
+            )]),
+            "Staking pool account IDs for the requested account",
+            Some(json!({
+                "account_id": "mob.near",
+                "pools": ["zavodil.poolv1.near"]
+            })),
+            true,
+        ),
+        get_operation_spec::<V0ContractsResponse>(
+            &mut registry,
+            "account_ft",
+            "FastNEAR API - V0 Account FT",
+            "/v0/account/{account_id}/ft",
+            "account_ft_v0",
+            "Lookup fungible token contract IDs for an account",
+            "Returns only fungible token contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include balances or block-height metadata.",
+            &["fungible-tokens"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("here.tg"),
+            )]),
+            "Fungible token contract IDs for the requested account",
+            Some(json!({
+                "account_id": "here.tg",
+                "contract_ids": ["wrap.near", "usdt.tether-token.near"]
+            })),
+            true,
+        ),
+        get_operation_spec::<V0ContractsResponse>(
+            &mut registry,
+            "account_nft",
+            "FastNEAR API - V0 Account NFT",
+            "/v0/account/{account_id}/nft",
+            "account_nft_v0",
+            "Lookup NFT contract IDs for an account",
+            "Returns only NFT contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.",
+            &["non-fungible-tokens"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("sharddog.near"),
+            )]),
+            "NFT contract IDs for the requested account",
+            Some(json!({
+                "account_id": "sharddog.near",
+                "contract_ids": ["nft.example.near"]
+            })),
+            true,
+        ),
+        get_operation_spec::<PublicKeyLookupResponse>(
+            &mut registry,
+            "public_key_lookup",
+            "FastNEAR API - V1 Public Key Lookup",
+            "/v1/public_key/{public_key}",
+            "lookup_by_public_key_v1",
+            "Lookup full-access accounts by public key",
+            "Returns account IDs currently associated with the supplied full-access public key. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.",
+            &["public-key"],
+            with_api_key(vec![path_parameter(
+                "public_key",
+                "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
+                json!("ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3"),
+            )]),
+            "Matching account IDs for the supplied full-access public key",
+            Some(json!({
+                "public_key": "ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3",
+                "account_ids": ["example.near"]
+            })),
+            true,
+        ),
+        get_operation_spec::<PublicKeyLookupResponse>(
+            &mut registry,
+            "public_key_lookup_all",
+            "FastNEAR API - V1 Public Key Lookup (All)",
+            "/v1/public_key/{public_key}/all",
+            "lookup_by_public_key_all_v1",
+            "Lookup all indexed accounts by public key",
+            "Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.",
+            &["public-key"],
+            with_api_key(vec![path_parameter(
+                "public_key",
+                "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
+                json!("ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd"),
+            )]),
+            "Matching account IDs for the supplied public key, including limited-access keys",
+            Some(json!({
+                "public_key": "ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd",
+                "account_ids": ["example.near", "limited.near"]
+            })),
+            true,
+        ),
+        get_operation_spec::<V1StakingResponse>(
+            &mut registry,
+            "account_staking",
+            "FastNEAR API - V1 Account Staking",
+            "/v1/account/{account_id}/staking",
+            "account_staking_v1",
+            "Lookup indexed staking pools for an account",
+            "Returns staking pool rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that pool relationship.",
+            &["staking"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("mob.near"),
+            )]),
+            "Indexed staking pool rows for the requested account",
+            Some(json!({
+                "account_id": "mob.near",
+                "pools": [
+                    {
+                        "pool_id": "zavodil.poolv1.near",
+                        "last_update_block_height": null
+                    }
+                ]
+            })),
+            true,
+        ),
+        get_operation_spec::<V1FtResponse>(
+            &mut registry,
+            "account_ft",
+            "FastNEAR API - V1 Account FT",
+            "/v1/account/{account_id}/ft",
+            "account_ft_v1",
+            "Lookup indexed fungible token rows for an account",
+            "Returns fungible token rows for the requested account. Balances and `last_update_block_height` remain nullable when the index has not recorded them yet.",
+            &["fungible-tokens"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("here.tg"),
+            )]),
+            "Indexed fungible token rows for the requested account",
+            Some(json!({
+                "account_id": "here.tg",
+                "tokens": [
+                    {
+                        "contract_id": "wrap.near",
+                        "last_update_block_height": null,
+                        "balance": "1000000000000000000000000"
+                    }
+                ]
+            })),
+            true,
+        ),
+        get_operation_spec::<V1NftResponse>(
+            &mut registry,
+            "account_nft",
+            "FastNEAR API - V1 Account NFT",
+            "/v1/account/{account_id}/nft",
+            "account_nft_v1",
+            "Lookup indexed NFT contract rows for an account",
+            "Returns NFT contract rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that contract relationship.",
+            &["non-fungible-tokens"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("sharddog.near"),
+            )]),
+            "Indexed NFT contract rows for the requested account",
+            Some(json!({
+                "account_id": "sharddog.near",
+                "tokens": [
+                    {
+                        "contract_id": "nft.example.near",
+                        "last_update_block_height": null
+                    }
+                ]
+            })),
+            true,
+        ),
+        get_operation_spec::<TokenAccountsResponse>(
+            &mut registry,
+            "ft_top",
+            "FastNEAR API - V1 FT Top Holders",
+            "/v1/ft/{token_id}/top",
+            "ft_top_v1",
+            "Lookup top indexed holders for a fungible token",
+            "Returns the top indexed accounts by balance for the requested fungible token.",
+            &["fungible-tokens"],
+            with_api_key(vec![path_parameter(
+                "token_id",
+                "Fungible token contract account ID.",
+                json!("wrap.near"),
+            )]),
+            "Indexed top holders for the requested fungible token",
+            Some(json!({
+                "token_id": "wrap.near",
+                "accounts": [
+                    {
+                        "account_id": "mob.near",
+                        "balance": "979894691374420631019486155"
+                    }
+                ]
+            })),
+            true,
+        ),
+        get_operation_spec::<AccountFullResponse>(
+            &mut registry,
+            "account_full",
+            "FastNEAR API - V1 Account Full",
+            "/v1/account/{account_id}/full",
+            "account_full_v1",
+            "Lookup full indexed account information",
+            "Returns staking, fungible token, NFT, and account-state information for the requested account. `state` remains nullable when the account state has not been recorded.",
+            &["accounts"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("here.tg"),
+            )]),
+            "Full indexed account information for the requested account",
+            Some(json!({
+                "account_id": "here.tg",
+                "pools": [],
+                "tokens": [],
+                "nfts": [],
+                "state": {
+                    "balance": "1000000000000000000000000",
+                    "locked": "0",
+                    "storage_bytes": 512
+                }
+            })),
+            true,
+        ),
+    ];
+
+    if include_exp {
+        operations.push(get_operation_spec::<ExpFtWithBalancesResponse>(
+            &mut registry,
+            "ft_with_balances",
+            "FastNEAR API - Experimental FT With Balances",
+            "/exp/account/{account_id}/ft_with_balances",
+            "exp_ft_with_balances",
+            "Resolve fungible token balances for one account",
+            "Returns a token-to-balance map for the requested account. This endpoint is deploy-gated and not part of the default published FastNEAR portal until `EXPERIMENTAL_API=true` is enabled publicly.",
+            &["experimental"],
+            with_api_key(vec![path_parameter(
+                "account_id",
+                "NEAR account ID to inspect.",
+                json!("here.tg"),
+            )]),
+            "Token-to-balance map for the requested account",
+            Some(json!({
+                "account_id": "here.tg",
+                "tokens": {
+                    "wrap.near": "1000000000000000000000000",
+                    "usdt.tether-token.near": null
+                }
+            })),
+            true,
+        ));
+        operations.push(get_operation_spec::<TokenAccountsResponse>(
+            &mut registry,
+            "ft_all",
+            "FastNEAR API - Experimental FT Holders",
+            "/exp/ft/{token_id}/all",
+            "exp_ft_all",
+            "Get every indexed holder for a fungible token",
+            "Returns every indexed account FastNEAR has stored for the requested fungible token, without the v1 top-holder limit. This endpoint is deploy-gated and not part of the default published FastNEAR portal until `EXPERIMENTAL_API=true` is enabled publicly.",
+            &["experimental"],
+            with_api_key(vec![path_parameter(
+                "token_id",
+                "Fungible token contract account ID.",
+                json!("first.tkn.near"),
+            )]),
+            "All indexed holders for the requested fungible token",
+            Some(json!({
+                "token_id": "first.tkn.near",
+                "accounts": [
+                    {
+                        "account_id": "foundation.near",
+                        "balance": "1000000000"
+                    }
+                ]
+            })),
+            true,
+        ));
+    }
+
+    let components = registry.into_components();
+    let mut service_doc = build_service_doc(&SERVICE_INFO, operations, components);
+    patch_component_requirements(&mut service_doc);
+    write_or_check_yaml(output_root.join("openapi.yaml"), &service_doc, check)?;
+    Ok(())
+}
+
+fn get_operation_spec<Response>(
+    registry: &mut SchemaRegistry,
+    slug: &'static str,
+    title: &'static str,
+    path: &'static str,
+    operation_id: &'static str,
+    summary: &'static str,
+    description: &'static str,
+    tags: &'static [&'static str],
+    parameters: Vec<ParameterSpec<'static>>,
+    ok_description: &'static str,
+    ok_example: Option<Value>,
+    include_bad_request: bool,
+) -> AggregateOperationSpec<'static>
+where
+    Response: JsonSchema,
+{
+    let response = registry.schema_ref::<Response>();
+
+    let mut responses = vec![ResponseSpec {
+        status: "200",
+        description: ok_description,
+        content: Some(ResponseContent::Json {
+            schema: response,
+            example: ok_example,
+            examples: vec![],
+        }),
+    }];
+
+    if include_bad_request {
+        responses.push(ResponseSpec {
+            status: "400",
+            description: "Bad Request",
+            content: Some(ResponseContent::Json {
+                schema: json!({ "type": "string" }),
+                example: None,
+                examples: vec![],
+            }),
+        });
+    }
+
+    responses.push(ResponseSpec {
+        status: "500",
+        description: "Internal Server Error",
+        content: Some(ResponseContent::Json {
+            schema: json!({ "type": "string" }),
+            example: None,
+            examples: vec![],
+        }),
+    });
+
+    AggregateOperationSpec {
+        slug,
+        title,
+        path,
+        method: HttpMethod::Get,
+        operation_id,
+        summary,
+        description,
+        tags,
+        parameters,
+        request_body: None,
+        responses,
+    }
+}
+
+fn api_key_parameter() -> ParameterSpec<'static> {
+    ParameterSpec {
+        name: "apiKey",
+        location: ParameterLocation::Query,
+        required: false,
+        description:
+            "Optional API key forwarded by embedded portal clients. The public FastNEAR API does not require it.",
+        schema: json!({ "type": "string" }),
+        example: None,
+    }
+}
+
+fn path_parameter(
+    name: &'static str,
+    description: &'static str,
+    example: Value,
+) -> ParameterSpec<'static> {
+    ParameterSpec {
+        name,
+        location: ParameterLocation::Path,
+        required: true,
+        description,
+        schema: json!({ "type": "string" }),
+        example: Some(example),
+    }
+}
+
+fn with_api_key(mut parameters: Vec<ParameterSpec<'static>>) -> Vec<ParameterSpec<'static>> {
+    parameters.push(api_key_parameter());
+    parameters
+}
+
+fn patch_component_requirements(doc: &mut Value) {
+    let schemas = doc["components"]["schemas"].as_object_mut().unwrap();
+    set_required(
+        schemas,
+        "StatusResponse",
+        &[
+            "version",
+            "sync_block_height",
+            "sync_latency_sec",
+            "sync_block_timestamp_nanosec",
+            "sync_balance_block_height",
+        ],
+    );
+    set_required(schemas, "HealthResponse", &["status"]);
+    set_required(
+        schemas,
+        "PublicKeyLookupResponse",
+        &["public_key", "account_ids"],
+    );
+    set_required(schemas, "V0StakingResponse", &["account_id", "pools"]);
+    set_required(
+        schemas,
+        "V0ContractsResponse",
+        &["account_id", "contract_ids"],
+    );
+    set_required(schemas, "PoolRow", &["pool_id", "last_update_block_height"]);
+    set_required(
+        schemas,
+        "TokenRow",
+        &["contract_id", "last_update_block_height", "balance"],
+    );
+    set_required(
+        schemas,
+        "NftRow",
+        &["contract_id", "last_update_block_height"],
+    );
+    set_required(schemas, "V1StakingResponse", &["account_id", "pools"]);
+    set_required(schemas, "V1FtResponse", &["account_id", "tokens"]);
+    set_required(schemas, "V1NftResponse", &["account_id", "tokens"]);
+    set_required(schemas, "AccountBalanceRow", &["account_id", "balance"]);
+    set_required(schemas, "TokenAccountsResponse", &["token_id", "accounts"]);
+    set_required(
+        schemas,
+        "AccountStateResponse",
+        &["balance", "locked", "storage_bytes"],
+    );
+    set_required(
+        schemas,
+        "AccountFullResponse",
+        &["account_id", "pools", "tokens", "nfts", "state"],
+    );
+    set_nullable_ref_property(
+        schemas,
+        "AccountFullResponse",
+        "state",
+        "#/components/schemas/AccountStateResponse",
+    );
+    set_required(
+        schemas,
+        "ExpFtWithBalancesResponse",
+        &["account_id", "tokens"],
+    );
+}
+
+fn set_required(
+    schemas: &mut serde_json::Map<String, Value>,
+    schema_name: &str,
+    required: &[&str],
+) {
+    let Some(schema) = schemas.get_mut(schema_name) else {
+        return;
+    };
+
+    schema.as_object_mut().unwrap().insert(
+        "required".to_string(),
+        Value::Array(
+            required
+                .iter()
+                .map(|field| Value::String((*field).to_string()))
+                .collect(),
+        ),
+    );
+}
+
+fn set_nullable_ref_property(
+    schemas: &mut serde_json::Map<String, Value>,
+    schema_name: &str,
+    property_name: &str,
+    reference: &str,
+) {
+    let Some(schema) = schemas.get_mut(schema_name) else {
+        return;
+    };
+
+    let Some(properties) = schema
+        .as_object_mut()
+        .and_then(|schema| schema.get_mut("properties"))
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+
+    let Some(property) = properties.get_mut(property_name) else {
+        return;
+    };
+
+    *property = json!({
+        "type": "object",
+        "allOf": [
+            {
+                "$ref": reference
+            }
+        ],
+        "nullable": true
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::patch_component_requirements;
+    use fastnear_openapi_generator::SchemaRegistry;
+    use serde_json::json;
+
+    use crate::types::{AccountFullResponse, PublicKeyLookupResponse, StatusResponse, TokenRow};
+
+    #[test]
+    fn component_requirement_patch_restores_required_nullable_fields() {
+        let mut registry = SchemaRegistry::openapi3();
+        registry.schema_ref::<StatusResponse>();
+        registry.schema_ref::<PublicKeyLookupResponse>();
+        registry.schema_ref::<TokenRow>();
+        registry.schema_ref::<AccountFullResponse>();
+
+        let mut doc = json!({
+            "components": {
+                "schemas": registry.into_components()
+            }
+        });
+        patch_component_requirements(&mut doc);
+
+        assert_eq!(
+            doc["components"]["schemas"]["StatusResponse"]["required"],
+            json!([
+                "version",
+                "sync_block_height",
+                "sync_latency_sec",
+                "sync_block_timestamp_nanosec",
+                "sync_balance_block_height"
+            ])
+        );
+        assert_eq!(
+            doc["components"]["schemas"]["TokenRow"]["required"],
+            json!(["contract_id", "last_update_block_height", "balance"])
+        );
+        assert_eq!(
+            doc["components"]["schemas"]["AccountFullResponse"]["properties"]["state"]["nullable"],
+            true
+        );
+    }
+}

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -80,12 +80,12 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             with_api_key(vec![path_parameter(
                 "public_key",
                 "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
-                json!("ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3"),
+                json!("ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"),
             )]),
             "Matching account IDs for the supplied full-access public key",
             Some(json!({
-                "public_key": "ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3",
-                "account_ids": ["example.near"]
+                "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT",
+                "account_ids": ["root.near"]
             })),
             true,
         ),
@@ -101,12 +101,12 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             with_api_key(vec![path_parameter(
                 "public_key",
                 "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
-                json!("ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd"),
+                json!("ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"),
             )]),
             "Matching account IDs for the supplied public key, including limited-access keys",
             Some(json!({
-                "public_key": "ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd",
-                "account_ids": ["example.near", "limited.near"]
+                "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT",
+                "account_ids": ["root.near"]
             })),
             true,
         ),
@@ -185,12 +185,12 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             with_api_key(vec![path_parameter(
                 "public_key",
                 "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
-                json!("ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3"),
+                json!("ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"),
             )]),
             "Matching account IDs for the supplied full-access public key",
             Some(json!({
-                "public_key": "ed25519:FekbqN74kXhVPRd8ysAqJwLydFvTPYh7ZXHmhqCETcR3",
-                "account_ids": ["example.near"]
+                "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT",
+                "account_ids": ["root.near"]
             })),
             true,
         ),
@@ -206,12 +206,12 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             with_api_key(vec![path_parameter(
                 "public_key",
                 "NEAR public key in `ed25519:...` or `secp256k1:...` form.",
-                json!("ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd"),
+                json!("ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT"),
             )]),
             "Matching account IDs for the supplied public key, including limited-access keys",
             Some(json!({
-                "public_key": "ed25519:HLcgpHWRn3ij97JfpPNYDScMXVguWSFH1mR58RB7qPpd",
-                "account_ids": ["example.near", "limited.near"]
+                "public_key": "ed25519:CCaThr3uokqnUs6Z5vVnaDcJdrfuTpYJHJWcAGubDjT",
+                "account_ids": ["root.near"]
             })),
             true,
         ),

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -41,7 +41,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/status",
             "get_status",
             "Get service sync status",
-            "Returns the latest indexed sync heights, the indexed block timestamp, the measured sync latency, and the deployed FastNEAR API version.",
+            "Check the current indexed block height, latency, and deployed service version.",
             &["system"],
             vec![api_key_parameter()],
             "Current FastNEAR API sync status",
@@ -61,7 +61,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/health",
             "get_health",
             "Get service health",
-            "Returns `ok` when the service is healthy. When FastNEAR is degraded, the same `status` field carries a diagnostic string instead.",
+            "Use this lightweight probe to confirm the FastNear API is healthy.",
             &["system"],
             vec![api_key_parameter()],
             "Health status string",
@@ -75,7 +75,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/public_key/{public_key}",
             "lookup_by_public_key_v0",
             "Lookup full-access accounts by public key",
-            "Returns account IDs currently associated with the provided full-access public key. The response includes account IDs only.",
+            "Fetch the indexed account IDs associated with a full-access public key.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -96,7 +96,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/public_key/{public_key}/all",
             "lookup_by_public_key_all_v0",
             "Lookup all indexed accounts by public key",
-            "Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index.",
+            "Use this variant when one public key may control multiple accounts and you want the full set.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -117,7 +117,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/account/{account_id}/staking",
             "account_staking_v0",
             "Lookup staking pool account IDs for an account",
-            "Returns staking pool account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.",
+            "Fetch the staking pool account IDs FastNear has indexed for one account. This v0 route returns pool IDs only, without block-height metadata.",
             &["staking"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -138,7 +138,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/account/{account_id}/ft",
             "account_ft_v0",
             "Lookup fungible token contract IDs for an account",
-            "Returns only fungible token contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include balances or block-height metadata.",
+            "Retrieve the indexed fungible token contract IDs for an account. This v0 route does not return balances.",
             &["fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -159,7 +159,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/account/{account_id}/nft",
             "account_nft_v0",
             "Lookup NFT contract IDs for an account",
-            "Returns only NFT contract account IDs that FastNEAR has indexed for the requested account. Unlike the v1 route, this response does not include `last_update_block_height` metadata.",
+            "Fetch the indexed NFT contract IDs associated with an account. This v0 route does not include block-height metadata.",
             &["non-fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -180,7 +180,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/public_key/{public_key}",
             "lookup_by_public_key_v1",
             "Lookup full-access accounts by public key",
-            "Returns account IDs currently associated with the supplied full-access public key. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.",
+            "Use the v1 endpoint for the newer namespace. It currently returns the same response shape as the v0 route.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -201,7 +201,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/public_key/{public_key}/all",
             "lookup_by_public_key_all_v1",
             "Lookup all indexed accounts by public key",
-            "Returns account IDs currently associated with the supplied public key, including limited-access keys when they are present in the FastNEAR index. This v1 route currently uses the same `{ public_key, account_ids }` response shape as the v0 route.",
+            "Fetch every indexed account tied to a public key. This v1 route currently uses the same response shape as the v0 route.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -222,7 +222,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/account/{account_id}/staking",
             "account_staking_v1",
             "Lookup indexed staking pools for an account",
-            "Returns staking pool rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that pool relationship.",
+            "Retrieve staking pool rows for an account, including block-height metadata for each pool relationship.",
             &["staking"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -248,7 +248,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/account/{account_id}/ft",
             "account_ft_v1",
             "Lookup indexed fungible token rows for an account",
-            "Returns fungible token rows for the requested account. Balances and `last_update_block_height` remain nullable when the index has not recorded them yet.",
+            "Fetch the v1 indexed fungible token balance rows for one account.",
             &["fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -275,7 +275,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/account/{account_id}/nft",
             "account_nft_v1",
             "Lookup indexed NFT contract rows for an account",
-            "Returns NFT contract rows for the requested account. `last_update_block_height` is nullable when FastNEAR has not recorded a recent indexed update for that contract relationship.",
+            "Fetch NFT contract rows for an account, including block-height metadata for each contract.",
             &["non-fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -301,7 +301,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/ft/{token_id}/top",
             "ft_top_v1",
             "Lookup top indexed holders for a fungible token",
-            "Returns the top indexed accounts by balance for the requested fungible token.",
+            "Use this endpoint to inspect the indexed top holders for a fungible token contract.",
             &["fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "token_id",
@@ -327,7 +327,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/account/{account_id}/full",
             "account_full_v1",
             "Lookup full indexed account information",
-            "Returns staking, fungible token, NFT, and account-state information for the requested account. `state` remains nullable when the account state has not been recorded.",
+            "Fetch the combined indexed account view, including staking pools, FT balances, NFTs, and account state.",
             &["accounts"],
             with_api_key(vec![path_parameter(
                 "account_id",

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -61,7 +61,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/health",
             "get_health",
             "Get service health",
-            "Use this lightweight probe to confirm the FastNear API is healthy.",
+            "Ping the FastNEAR API for liveness — returns `{status: ok}` when healthy.",
             &["system"],
             vec![api_key_parameter()],
             "Health status string",
@@ -96,7 +96,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/public_key/{public_key}/all",
             "lookup_by_public_key_all_v0",
             "Lookup all indexed accounts by public key",
-            "Use this variant when one public key may control multiple accounts and you want the full set.",
+            "Fetch every account tied to a public key — full-access and limited-access keys together.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -117,7 +117,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/account/{account_id}/staking",
             "account_staking_v0",
             "Lookup staking pool account IDs for an account",
-            "Fetch the staking pool account IDs FastNear has indexed for one account. This v0 route returns pool IDs only, without block-height metadata.",
+            "Fetch staking pool account IDs for one account — pool IDs only, no block-height metadata.",
             &["staking"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -138,7 +138,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/account/{account_id}/ft",
             "account_ft_v0",
             "Lookup fungible token contract IDs for an account",
-            "Retrieve the indexed fungible token contract IDs for an account. This v0 route does not return balances.",
+            "Fetch the fungible token contract IDs an account has held — contract IDs only, no balances.",
             &["fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -159,7 +159,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v0/account/{account_id}/nft",
             "account_nft_v0",
             "Lookup NFT contract IDs for an account",
-            "Fetch the indexed NFT contract IDs associated with an account. This v0 route does not include block-height metadata.",
+            "Fetch the NFT contract IDs an account has held — contract IDs only, no block-height metadata.",
             &["non-fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -180,7 +180,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/public_key/{public_key}",
             "lookup_by_public_key_v1",
             "Lookup full-access accounts by public key",
-            "Use the v1 endpoint for the newer namespace. It currently returns the same response shape as the v0 route.",
+            "Fetch the indexed account IDs associated with a full-access public key.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -201,7 +201,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/public_key/{public_key}/all",
             "lookup_by_public_key_all_v1",
             "Lookup all indexed accounts by public key",
-            "Fetch every indexed account tied to a public key. This v1 route currently uses the same response shape as the v0 route.",
+            "Fetch every account tied to a public key — full-access and limited-access keys together.",
             &["public-key"],
             with_api_key(vec![path_parameter(
                 "public_key",
@@ -248,7 +248,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/account/{account_id}/ft",
             "account_ft_v1",
             "Lookup indexed fungible token rows for an account",
-            "Fetch the v1 indexed fungible token balance rows for one account.",
+            "Fetch an account's fungible token balance rows, each with contract ID, balance, and last-update block height.",
             &["fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -301,7 +301,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/v1/ft/{token_id}/top",
             "ft_top_v1",
             "Lookup top indexed holders for a fungible token",
-            "Use this endpoint to inspect the indexed top holders for a fungible token contract.",
+            "Fetch the top-balance holder list for a fungible token contract, ranked highest balance first.",
             &["fungible-tokens"],
             with_api_key(vec![path_parameter(
                 "token_id",
@@ -358,7 +358,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/exp/account/{account_id}/ft_with_balances",
             "exp_ft_with_balances",
             "Resolve fungible token balances for one account",
-            "Returns a token-to-balance map for the requested account. This endpoint is deploy-gated and not part of the default published FastNEAR portal until `EXPERIMENTAL_API=true` is enabled publicly.",
+            "Fetch an account's fungible token holdings as a flat `contract_id → balance` map in one response.",
             &["experimental"],
             with_api_key(vec![path_parameter(
                 "account_id",
@@ -382,7 +382,7 @@ pub fn generate(check: bool, include_exp: bool) -> Result<()> {
             "/exp/ft/{token_id}/all",
             "exp_ft_all",
             "Get every indexed holder for a fungible token",
-            "Returns every indexed account FastNEAR has stored for the requested fungible token, without the v1 top-holder limit. This endpoint is deploy-gated and not part of the default published FastNEAR portal until `EXPERIMENTAL_API=true` is enabled publicly.",
+            "Fetch every indexed holder of a fungible token — unbounded list, no top-holder truncation.",
             &["experimental"],
             with_api_key(vec![path_parameter(
                 "token_id",

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,4 +1,4 @@
-use crate::api::BlockHeight;
+use crate::types::BlockHeight;
 use base64::prelude::*;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,11 +1,10 @@
-use crate::api::HealthError;
-use crate::*;
 use actix_web::{get, web, Responder};
-use serde_json::json;
 
-async fn internal_status(
-    app_state: &web::Data<AppState>,
-) -> Result<serde_json::Value, api::ServiceError> {
+use crate::api::{HealthError, ServiceError};
+use crate::types::{HealthResponse, StatusResponse};
+use crate::{database, AppState, Config};
+
+async fn internal_status(app_state: &web::Data<AppState>) -> Result<StatusResponse, ServiceError> {
     let mut connection = app_state
         .redis_client
         .get_multiplexed_async_connection()
@@ -16,26 +15,26 @@ async fn internal_status(
     let latest_balance_block =
         database::query_get(&mut connection, "meta:latest_balance_block").await?;
 
-    let sync_latency_sec = latest_block_time.as_ref().map(|t| {
-        let t_nano = t.parse::<u128>().unwrap_or(0);
+    let sync_latency_sec = latest_block_time.as_ref().map(|timestamp| {
+        let timestamp_nanos = timestamp.parse::<u128>().unwrap_or(0);
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default();
-        now.as_nanos().saturating_sub(t_nano) as f64 / 1e9
+        now.as_nanos().saturating_sub(timestamp_nanos) as f64 / 1e9
     });
 
-    Ok(json!({
-        "version": env!("CARGO_PKG_VERSION"),
-        "sync_block_height": latest_sync_block.map(|s| s.parse::<u64>().unwrap_or(0)),
-        "sync_latency_sec": sync_latency_sec,
-        "sync_block_timestamp_nanosec": latest_block_time,
-        "sync_balance_block_height": latest_balance_block.map(|s| s.parse::<u64>().unwrap_or(0)),
-    }))
+    Ok(StatusResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        sync_block_height: latest_sync_block.and_then(|value| value.parse::<u64>().ok()),
+        sync_latency_sec,
+        sync_block_timestamp_nanosec: latest_block_time,
+        sync_balance_block_height: latest_balance_block.and_then(|value| value.parse::<u64>().ok()),
+    })
 }
 
-fn is_healthy(v: serde_json::Value, config: &Config) -> Result<(), HealthError> {
-    let latency = v["sync_latency_sec"]
-        .as_f64()
+fn is_healthy(status_response: &StatusResponse, config: &Config) -> Result<(), HealthError> {
+    let latency = status_response
+        .sync_latency_sec
         .ok_or(HealthError::MissingSyncLatency)?;
     if latency > config.max_healthy_latency_sec {
         return Err(HealthError::HighSyncLatency {
@@ -43,11 +42,12 @@ fn is_healthy(v: serde_json::Value, config: &Config) -> Result<(), HealthError> 
             max_latency: config.max_healthy_latency_sec,
         });
     }
-    let latest_sync_block = v["sync_block_height"]
-        .as_u64()
+
+    let latest_sync_block = status_response
+        .sync_block_height
         .ok_or(HealthError::MissingSyncBlockHeight)?;
-    let latest_balance_block = v["sync_balance_block_height"]
-        .as_u64()
+    let latest_balance_block = status_response
+        .sync_balance_block_height
         .ok_or(HealthError::MissingSyncBalanceBlockHeight)?;
     let sync_difference = latest_sync_block.saturating_sub(latest_balance_block);
     if sync_difference > config.max_healthy_sync_block_diff {
@@ -56,20 +56,23 @@ fn is_healthy(v: serde_json::Value, config: &Config) -> Result<(), HealthError> 
             max_sync_difference: config.max_healthy_sync_block_diff,
         });
     }
+
     Ok(())
 }
 
 #[get("/status")]
-pub async fn status(
-    app_state: web::Data<AppState>,
-) -> Result<impl Responder, crate::api::ServiceError> {
-    internal_status(&app_state).await.map(|res| web::Json(res))
+pub async fn status(app_state: web::Data<AppState>) -> Result<impl Responder, ServiceError> {
+    internal_status(&app_state).await.map(web::Json)
 }
 
 #[get("/health")]
-pub async fn health(app_state: web::Data<AppState>) -> Result<impl Responder, api::ServiceError> {
-    let res = internal_status(&app_state).await?;
-    Ok(web::Json(
-        json!({"status": is_healthy(res, &app_state.config).map(|_| "ok".to_string()).unwrap_or_else(|e| format!("{:?}", e))}),
-    ))
+pub async fn health(app_state: web::Data<AppState>) -> Result<impl Responder, ServiceError> {
+    let status_response = internal_status(&app_state).await?;
+    let response = HealthResponse {
+        status: is_healthy(&status_response, &app_state.config)
+            .map(|_| "ok".to_string())
+            .unwrap_or_else(|error| format!("{:?}", error)),
+    };
+
+    Ok(web::Json(response))
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,358 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+pub type BlockHeight = u64;
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct StatusResponse {
+    pub version: String,
+    pub sync_block_height: Option<BlockHeight>,
+    pub sync_latency_sec: Option<f64>,
+    pub sync_block_timestamp_nanosec: Option<String>,
+    pub sync_balance_block_height: Option<BlockHeight>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct HealthResponse {
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct PublicKeyLookupResponse {
+    pub public_key: String,
+    pub account_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct V0StakingResponse {
+    pub account_id: String,
+    pub pools: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct V0ContractsResponse {
+    pub account_id: String,
+    pub contract_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct PoolRow {
+    pub pool_id: String,
+    pub last_update_block_height: Option<BlockHeight>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct TokenRow {
+    pub contract_id: String,
+    pub last_update_block_height: Option<BlockHeight>,
+    pub balance: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct NftRow {
+    pub contract_id: String,
+    pub last_update_block_height: Option<BlockHeight>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct V1StakingResponse {
+    pub account_id: String,
+    pub pools: Vec<PoolRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct V1FtResponse {
+    pub account_id: String,
+    pub tokens: Vec<TokenRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct V1NftResponse {
+    pub account_id: String,
+    pub tokens: Vec<NftRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct AccountBalanceRow {
+    pub account_id: String,
+    pub balance: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct TokenAccountsResponse {
+    pub token_id: String,
+    pub accounts: Vec<AccountBalanceRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct AccountStateResponse {
+    pub balance: Option<String>,
+    pub locked: Option<String>,
+    pub storage_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct AccountFullResponse {
+    pub account_id: String,
+    pub pools: Vec<PoolRow>,
+    pub tokens: Vec<TokenRow>,
+    pub nfts: Vec<NftRow>,
+    pub state: Option<AccountStateResponse>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct ExpFtWithBalancesResponse {
+    pub account_id: String,
+    pub tokens: HashMap<String, Option<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredAccountState {
+    #[serde(rename = "b", default)]
+    balance: Option<String>,
+    #[serde(rename = "l", default)]
+    locked: Option<String>,
+    #[serde(rename = "s", default)]
+    storage_bytes: Option<u64>,
+}
+
+pub fn parse_account_state(raw_state: Option<String>) -> Option<AccountStateResponse> {
+    raw_state.and_then(|state| {
+        if state.is_empty() {
+            return None;
+        }
+
+        serde_json::from_str::<StoredAccountState>(&state)
+            .ok()
+            .map(|stored| AccountStateResponse {
+                balance: stored.balance,
+                locked: stored.locked,
+                storage_bytes: stored.storage_bytes,
+            })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+
+    use super::{
+        parse_account_state, AccountBalanceRow, AccountFullResponse, ExpFtWithBalancesResponse,
+        HealthResponse, NftRow, PoolRow, PublicKeyLookupResponse, StatusResponse,
+        TokenAccountsResponse, TokenRow, V0ContractsResponse, V0StakingResponse,
+    };
+
+    #[test]
+    fn system_responses_preserve_nullable_wire_shape() {
+        let status = StatusResponse {
+            version: "0.10.1".to_string(),
+            sync_block_height: Some(193_473_935),
+            sync_latency_sec: Some(2.159742085),
+            sync_block_timestamp_nanosec: Some("1775874067605835029".to_string()),
+            sync_balance_block_height: Some(193_473_935),
+        };
+        let health = HealthResponse {
+            status: "ok".to_string(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(status).unwrap(),
+            json!({
+                "version": "0.10.1",
+                "sync_block_height": 193473935,
+                "sync_latency_sec": 2.159742085,
+                "sync_block_timestamp_nanosec": "1775874067605835029",
+                "sync_balance_block_height": 193473935
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(health).unwrap(),
+            json!({ "status": "ok" })
+        );
+    }
+
+    #[test]
+    fn public_key_and_v0_responses_match_current_wire_format() {
+        let public_key = PublicKeyLookupResponse {
+            public_key: "ed25519:test".to_string(),
+            account_ids: vec!["example.near".to_string()],
+        };
+        let staking = V0StakingResponse {
+            account_id: "root.near".to_string(),
+            pools: vec!["zavodil.poolv1.near".to_string()],
+        };
+        let contracts = V0ContractsResponse {
+            account_id: "root.near".to_string(),
+            contract_ids: vec!["wrap.near".to_string()],
+        };
+
+        assert_eq!(
+            serde_json::to_value(public_key).unwrap(),
+            json!({
+                "public_key": "ed25519:test",
+                "account_ids": ["example.near"]
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(staking).unwrap(),
+            json!({
+                "account_id": "root.near",
+                "pools": ["zavodil.poolv1.near"]
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(contracts).unwrap(),
+            json!({
+                "account_id": "root.near",
+                "contract_ids": ["wrap.near"]
+            })
+        );
+    }
+
+    #[test]
+    fn account_full_and_top_holder_responses_preserve_nullable_fields() {
+        let token_accounts = TokenAccountsResponse {
+            token_id: "first.tkn.near".to_string(),
+            accounts: vec![AccountBalanceRow {
+                account_id: "mob.near".to_string(),
+                balance: Some("979894691374420631019486155".to_string()),
+            }],
+        };
+        let full = AccountFullResponse {
+            account_id: "here.tg".to_string(),
+            pools: vec![PoolRow {
+                pool_id: "here.poolv1.near".to_string(),
+                last_update_block_height: None,
+            }],
+            tokens: vec![TokenRow {
+                contract_id: "v1.omni.hot.tg".to_string(),
+                last_update_block_height: Some(128_025_061),
+                balance: Some(String::new()),
+            }],
+            nfts: vec![NftRow {
+                contract_id: "nft.hot.tg".to_string(),
+                last_update_block_height: Some(115_282_010),
+            }],
+            state: Some(
+                parse_account_state(Some(
+                    r#"{"b":"323562725144261345105389596","l":"0","s":29720}"#.to_string(),
+                ))
+                .unwrap(),
+            ),
+        };
+
+        assert_eq!(
+            serde_json::to_value(token_accounts).unwrap(),
+            json!({
+                "token_id": "first.tkn.near",
+                "accounts": [
+                    {
+                        "account_id": "mob.near",
+                        "balance": "979894691374420631019486155"
+                    }
+                ]
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(full).unwrap(),
+            json!({
+                "account_id": "here.tg",
+                "pools": [
+                    {
+                        "pool_id": "here.poolv1.near",
+                        "last_update_block_height": null
+                    }
+                ],
+                "tokens": [
+                    {
+                        "contract_id": "v1.omni.hot.tg",
+                        "last_update_block_height": 128025061,
+                        "balance": ""
+                    }
+                ],
+                "nfts": [
+                    {
+                        "contract_id": "nft.hot.tg",
+                        "last_update_block_height": 115282010
+                    }
+                ],
+                "state": {
+                    "balance": "323562725144261345105389596",
+                    "locked": "0",
+                    "storage_bytes": 29720
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn exp_shapes_preserve_map_and_row_formats() {
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "wrap.near".to_string(),
+            Some("4200000000000000000000000".to_string()),
+        );
+        tokens.insert("usdt.tether-token.near".to_string(), None);
+        let response = ExpFtWithBalancesResponse {
+            account_id: "here.tg".to_string(),
+            tokens,
+        };
+
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["account_id"], "here.tg");
+        assert_eq!(json["tokens"]["wrap.near"], "4200000000000000000000000");
+        assert!(json["tokens"]["usdt.tether-token.near"].is_null());
+    }
+
+    #[test]
+    fn empty_or_invalid_account_state_stays_nullable() {
+        assert!(parse_account_state(Some(String::new())).is_none());
+        assert!(parse_account_state(Some("{".to_string())).is_none());
+        assert_eq!(
+            serde_json::to_value(
+                parse_account_state(Some(r#"{"b":"1","l":"0"}"#.to_string())).unwrap()
+            )
+            .unwrap(),
+            json!({
+                "balance": "1",
+                "locked": "0",
+                "storage_bytes": null
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This moves `fastnear-api-server-rs` to owning its aggregate OpenAPI document in-repo.

The checked-in `openapi/openapi.yaml` file is now generated from typed Rust DTOs plus a Rust-owned operation registry, instead of being maintained outside the service repo.

## What changed

- add an `openapi` feature with a `generate-openapi` binary
- add `src/openapi.rs` to build the aggregate OpenAPI document
- check in `openapi/openapi.yaml`
- move shared app state, scopes, and docs-serving handlers into `lib.rs` so both the server binary and the OpenAPI generator can reuse them
- expose the DTOs needed for aggregate OpenAPI generation in `src/types.rs`
- update README docs to describe the current docs pipeline

This covers system, v0, v1, and optional experimental aggregate OpenAPI generation from the Rust operation registry.

## Why the `main.rs` -> `lib.rs` split

This is not intended as an architectural rewrite.

Rust binaries cannot be imported by other binaries, so the new `generate-openapi` binary needed a small shared library surface for:
- app state types
- route scopes and docs handlers
- request and response DTOs

The server startup flow remains in `main.rs`; the shared reusable pieces moved to `lib.rs`.

## What did not change

- the public HTTP routes and handlers remain the same
- the API module cleanup is in support of the generator and shared DTO exposure, not a product-level behavior change
- server startup, env loading, logging, and binding remain in `main.rs`
- portal-owned per-operation splitting and docs enhancements still live outside this repo

## Validation

```bash
cargo check
cargo run --features openapi --bin generate-openapi -- --check
```
